### PR TITLE
Remove stray addKnownSafeSites() call from background.js

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -858,9 +858,6 @@ async function initializeExtension() {
       }
     }
 
-    // Add fallback known sites - only for safe sites, not for starred
-    addKnownSafeSites();
-
     // Set up the update schedule
     await setupUpdateSchedule();
 


### PR DESCRIPTION
Remove stray addKnownSafeSites() call

After deleting the addKnownSafeSites() function in the previous commit, this call remained and is now removed to avoid errors.